### PR TITLE
feat: Allow jsonfly on unnamed buffers

### DIFF
--- a/lua/telescope/_extensions/jsonfly.lua
+++ b/lua/telescope/_extensions/jsonfly.lua
@@ -143,7 +143,7 @@ return require"telescope".register_extension {
                 show_picker(keys, current_buf)
             end
 
-            if opts.backend == "lsp" then
+            if opts.backend == "lsp" and vim.bo.filetype == 'json' then
                 local params = vim.lsp.util.make_position_params(xopts.winnr)
 
                 vim.lsp.buf_request(


### PR DESCRIPTION
The changes here simply check if the filetype is `json`, and if so, continue to assume an lsp is attached. Otherwise the fallback code is triggered that works without an LSP.

I've left some discussion points in #5.